### PR TITLE
Fix sizes reported for devices with phys. bs != 512b

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -969,7 +969,7 @@ class LinuxHardware(Hardware):
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/physical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size",512)
-                    part['size'] = module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
+                    part['size'] = module.pretty_bytes((float(part['sectors']) * 512))
                     d['partitions'][partname] = part
 
             d['rotational'] = get_file_content(sysdir + "/queue/rotational")
@@ -986,7 +986,7 @@ class LinuxHardware(Hardware):
             d['sectorsize'] = get_file_content(sysdir + "/queue/physical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size",512)
-            d['size'] = module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
+            d['size'] = module.pretty_bytes(float(d['sectors']) * 512)
 
             d['host'] = ""
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 1.9.6 (stable-1.9 10a38a7652) last updated 2016/04/21 10:30:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 6972d0a291) last updated 2016/04/21 15:37:22 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2c073442b0) last updated 2016/04/21 15:37:22 (GMT +200)
  configured module search path = None
```

##### SUMMARY
This fixes incorrectly calculated sizes for block devices whose reported physical sector size doesn't equal 512 bytes.

```
Before:
            "sdb": {
                "holders": [], 
                "host": "SATA controller: Intel Corporation Wellsburg 6-Port SATA Controller [AHCI mode] (rev 05)", 
                "model": "Crucial_CT128MX1", 
[...]
                "sectors": "250069680", 
                "sectorsize": "4096", 
                "size": "953.94 GB", 
                "support_discard": "4096", 
                "vendor": "ATA"
            }, 

            "sr0": {
                "holders": [], 
                "host": "USB controller: Intel Corporation Wellsburg USB Enhanced Host Controller #1 (rev 05)", 
                "model": "Virtual CDROM", 
[...]
                "sectors": "1290240", 
                "sectorsize": "2048", 
                "size": "2.46 GB", 
                "support_discard": "0", 
                "vendor": "ATEN"
            }

After:

            "sdb": {
                "holders": [], 
                "host": "SATA controller: Intel Corporation Wellsburg 6-Port SATA Controller [AHCI mode] (rev 05)", 
                "model": "Crucial_CT128MX1", 
[...]
                "sectors": "250069680", 
                "sectorsize": "4096", 
                "size": "119.24 GB", 
                "support_discard": "4096", 
                "vendor": "ATA"
            }, 
            "sr0": {
                "holders": [], 
                "host": "USB controller: Intel Corporation Wellsburg USB Enhanced Host Controller #1 (rev 05)", 
                "model": "Virtual CDROM", 
[...]
                "sectors": "1290240", 
                "sectorsize": "2048", 
                "size": "630.00 MB", 
                "support_discard": "0", 
                "vendor": "ATEN"
            }
```